### PR TITLE
add a margin for small screens

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,3 +13,7 @@ code {
 blockquote {
   @apply text-gray-500;
 }
+
+body {
+  margin: 1em;
+}


### PR DESCRIPTION
the site doesn't have a margin on very small screens, and while there's probably a more "NextJS"-ish way to do this, this is quick and dirty and will get the job done.

Current `main` deployed on netlify:
![image](https://github.com/mrpbennett/personal-blog/assets/5070516/e36a8d60-2170-4c0a-96f2-71b61dc2709a)

This commit deployed on netlify:
![image](https://github.com/mrpbennett/personal-blog/assets/5070516/6986831c-7b99-43d5-a3af-488d75fb2365)