### PR TITLE
add default locale and labels for links

### DIFF
--- a/components/social.jsx
+++ b/components/social.jsx
@@ -5,13 +5,13 @@ import {MdEmail} from 'react-icons/md'
 export default function Social() {
   return (
     <div className="flex space-x-4">
-      <a href="https://github.com/mrpbennett">
+      <a href="https://github.com/mrpbennett" aria-label="github profile">
         <BsGithub className="h-6 w-6 hover:text-green-500" />
       </a>
-      <a href="https://www.linkedin.com/in/paulandrewbennett/">
+      <a href="https://www.linkedin.com/in/paulandrewbennett/" aria-label="linkedin profile">
         <BsLinkedin className="h-6 w-6 hover:text-green-500" />
       </a>
-      <a href="mailto:pbennett.uk@gmail.com">
+      <a href="mailto:pbennett.uk@gmail.com" aria-label="send me an email">
         <MdEmail className="h-6 w-6 hover:text-green-500" />
       </a>
     </div>

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  i18n: {
+    locales: ["en"],
+    defaultLocale: "en"
+  }
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
there are two issues impacting accessibility for the blog, so we can address them by adding a `lang` attribute and some labels for the links.

Current a11y score on `main`
![image](https://github.com/mrpbennett/personal-blog/assets/5070516/9b1bc6c2-6ec1-40c6-a612-557e396c51f6)

a11y score on current branch
![image](https://github.com/mrpbennett/personal-blog/assets/5070516/acf6c4f1-512b-4815-bf30-08b795854069)
